### PR TITLE
Fix checkmark not highlighted for watched items

### DIFF
--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -104,6 +104,7 @@ export function Timeline() {
         listSubscriptions(),
       ]);
       setData(contentData);
+      setConsumedIds(new Set(contentData.items.filter((i) => i.consumed).map((i) => i.id)));
       const subMap: Record<string, Subscription> = {};
       for (const s of subData) subMap[s.id] = s;
       setSubs(subMap);


### PR DESCRIPTION
Fix the green checkmark not showing on already-watched content cards.

Populate `consumedIds` from fetched item data so that already-watched content shows the green checkmark on load, not just after toggling.

Closes #6

Generated with [Claude Code](https://claude.ai/code)